### PR TITLE
Protect password input with asterisk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ joplin.plugins.register({
 		await dialogs.setHtml(handle2, `
 		<p>Please Enter your password</p>
 		<form name="user">
-			<input type="text" name="pwd"/>
+			<input type="password" name="pwd"/>
 		</form>
 		`);
 


### PR DESCRIPTION
change input type to "password" so that it won't be visible to any observers whilst writing.